### PR TITLE
PathCORE methods documentation and transfer from bitbucket

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, Greene Laboratory
+Copyright (c) 2017, Trustees of the University of Pennsylvania
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# PathCORE
-Methods to build a network of pathway co-occurrence relationships out of expression signatures extracted from transcriptomic compendia.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,49 @@
+PathCORE
+--------
+Python 3 implementation of methods described in
+Chen et al.'s 2017 PathCORE paper for identifying pathway-pathway
+interactions using features constructed from transcriptomic data.
+
+This code has been tested on Python 3.5.
+
+Installation
+----------------
+To install the current PyPI version (recommended), run::
+
+    pip install PathCORE
+
+For the latest GitHub version, run::
+
+    pip install git+https://github.com/greenelab/PathCORE.git#egg=PathCORE
+
+Package contents
+----------------
+
+=====================================
+feature_pathway_overrepresentation.py
+=====================================
+The methods in this module are used to identify the pathways
+overrepresented in features extracted from a transcriptomic dataset
+of genes-by-samples. Features must preserve the genes in the dataset
+and assign weights to these genes based on some distribution.
+
+===========
+network.py
+===========
+Contains the data structure ``CoNetwork`` that stores information
+about the pathway co-occurrence network. The output from
+a pathway enrichment analysis in ``feature_pathway_overrepresentation.py``
+serves as input into the ``CoNetwork`` constructor.
+
+============================
+network_permutation_test.py
+============================
+The methods in this module are used to filter the constructed
+co-occurence network. We implement a permutation test that evaluates
+and removes edges (pathway-pathway relationships) in the network
+that cannot be distinguished from a null model of random associations.
+The null model is created by generating _N_ permutations of the network.
+
+Acknowledgements
+----------------
+This work was supported by the Penn Institute for Bioinformatics

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ The methods in this module are used to filter the constructed
 co-occurence network. We implement a permutation test that evaluates
 and removes edges (pathway-pathway relationships) in the network
 that cannot be distinguished from a null model of random associations.
-The null model is created by generating _N_ permutations of the network.
+The null model is created by generating *N* permutations of the network.
 
 Acknowledgements
 ----------------

--- a/pathcore/__init__.py
+++ b/pathcore/__init__.py
@@ -5,10 +5,3 @@ from .feature_pathway_overrepresentation import \
 from .network import CoNetwork
 from .network_permutation_test import aggregate_permuted_network, \
         network_edges_permutation_test
-
-__all__ = ["CoNetwork",
-           "aggregate_permuted_network",
-           "network_edges_permutation_test",
-           "pathway_enrichment_no_overlap_correction",
-           "pathway_enrichment_with_overlap_correction",
-           "single_side_pathway_enrichment"]

--- a/pathcore/__init__.py
+++ b/pathcore/__init__.py
@@ -1,0 +1,14 @@
+from .feature_pathway_overrepresentation import \
+    pathway_enrichment_no_overlap_correction, \
+    pathway_enrichment_with_overlap_correction, \
+    single_side_pathway_enrichment
+from .network import CoNetwork
+from .network_permutation_test import aggregate_permuted_network, \
+        network_edges_permutation_test
+
+__all__ = ["CoNetwork",
+           "aggregate_permuted_network",
+           "network_edges_permutation_test",
+           "pathway_enrichment_no_overlap_correction",
+           "pathway_enrichment_with_overlap_correction",
+           "single_side_pathway_enrichment"]

--- a/pathcore/feature_pathway_overrepresentation.py
+++ b/pathcore/feature_pathway_overrepresentation.py
@@ -7,6 +7,11 @@ from scipy import stats
 from statsmodels.sandbox.stats.multicomp import multipletests
 
 
+# handle the floating point errors thrown in the Fisher's exact test
+# manually.
+np.seterr(all="raise")
+
+
 def pathway_enrichment_with_overlap_correction(feature_weight_vector,
                                                pathway_definitions,
                                                gene_signature_definition,

--- a/pathcore/feature_pathway_overrepresentation.py
+++ b/pathcore/feature_pathway_overrepresentation.py
@@ -131,6 +131,7 @@ def _significant_pathways_dataframe(pvalue_information,
     """
     significant_pathways = pd.concat(
         [pvalue_information, side_information], axis=1)
+    # fdr_bh: false discovery rate, Benjamini & Hochberg (1995, 2000)
     below_alpha, qvalues, _, _ = multipletests(
         significant_pathways["p-value"], alpha=alpha, method="fdr_bh")
     below_alpha = pd.Series(

--- a/pathcore/feature_pathway_overrepresentation.py
+++ b/pathcore/feature_pathway_overrepresentation.py
@@ -1,0 +1,284 @@
+"""Determine the pathways overrepresented in a constructed feature.
+"""
+from crosstalk_correction import crosstalk_correction
+import numpy as np
+import pandas as pd
+from scipy import stats
+from statsmodels.sandbox.stats.multicomp import multipletests
+
+
+def pathway_enrichment_with_overlap_correction(feature_weight_vector,
+                                               pathway_definitions,
+                                               gene_signature_definition,
+                                               alpha=0.05,
+                                               correct_all_genes=True,
+                                               metadata=False):
+    """Identify pathways overrepresented in a constructed feature
+    according to a user-specified criterion (see `gene_signature_definitions`
+    in the parameters list below) for identifying the feature's gene
+    signature. Donato et al.'s (2013) algorithm for pathway crosstalk
+    correction (removes gene overlap between pathway definitions) is applied to
+    the pathway definitions before overrepresentation analysis.
+    Here, we refer to it as *overlap-correction*.
+
+    Parameters
+    -----------
+    feature_weight_vector : pandas.Series(float), shape = n
+      A vector containing gene weights
+    pathway_definitions : dict(str -> set(str))
+      A pathway (key) is defined by a set of genes (value).
+    gene_signature_definition : functools.partial callable,
+                                returns (set(), set())
+      Accepts the `feature_weight_vector` as input. Provide a function to
+      distinguish positive and/or negative gene signatures.
+      Both a positive & a negative signature may be appropriate if the
+      feature's gene weight distribution spans positive and negative values.
+      If this is not the case, specify a single gene signature by returning
+      one of the sides as an empty set.
+    alpha : float (default=0.05)
+      Significance level for pathway enrichment.
+    correct_all_genes : bool (default=True)
+      The overlap correction procedure is applied independently to both
+      the gene signature (union of positive and negative signature when
+      applicable) _and_ the genes outside of the signature (termed
+      *remaining* genes).
+      If not `correct_all_genes`, overlap correction is not applied to
+      the set of remaining genes.
+    metadata : bool (default=False)
+      Gather information to store in a MongoDB-backed Flask web application.
+      Users can interact with the PathCORE-produced network and analyze the
+      genes underlying a pair of pathways linked in the network.
+
+    Returns
+    -----------
+    tup([pandas.DataFrame|None], dict())
+    tup[0] : pandas.DataFrame: dataframe of significant pathways
+           | None if the gene signature does not contain any genes in the
+                  pathway definitions
+    tup[1] : if `metadata`:
+             {"positive signature": <set() positive gene signature>,
+              "negative signature": <set() negative gene signature>,
+              "pathway definitions": <dict(str -> set())
+                overlap-corrected definitions--only signature genes>}
+             else: {}
+    """
+    genes_in_pathway_definitions = set.union(*pathway_definitions.values())
+    positive_gene_signature, negative_gene_signature = \
+        gene_signature_definition(feature_weight_vector)
+    gene_signature = ((positive_gene_signature | negative_gene_signature) &
+                      genes_in_pathway_definitions)
+    if not gene_signature:
+        return (None, {})
+
+    additional_information = {}
+    n_genes = len(feature_weight_vector)
+
+    if metadata:
+        additional_information["positive_signature"] = (
+          positive_gene_signature & gene_signature)
+        additional_information["negative_signature"] = (
+          negative_gene_signature & gene_signature)
+    corrected_pathway_definitions = crosstalk_correction(
+        pathway_definitions,
+        gene_set=gene_signature,
+        all_genes=correct_all_genes)
+
+    if metadata:
+        collect_signature_pathway_definitions = {}
+        for pathway, (signature_defn, remaining_defn) in \
+                corrected_pathway_definitions.items():
+            collect_signature_pathway_definitions[pathway] = signature_defn
+        additional_information["pathway_definitions"] = \
+            collect_signature_pathway_definitions
+
+    pathway_positive_series = single_side_pathway_enrichment(
+        corrected_pathway_definitions, positive_gene_signature, n_genes)
+    pathway_negative_series = single_side_pathway_enrichment(
+        corrected_pathway_definitions, negative_gene_signature, n_genes)
+
+    pvalue_information = pathway_positive_series.append(
+        pathway_negative_series)
+    side_information = _pathway_side_information(
+        pathway_positive_series, pathway_negative_series,
+        pvalue_information.index)
+    significant_pathways = _significant_pathways_dataframe(
+        pvalue_information, side_information, alpha)
+    return significant_pathways, additional_information
+
+
+def _pathway_side_information(pathway_positive_series,
+                              pathway_negative_series,
+                              index):
+    """Create the pandas.Series containing the side labels that correspond
+    to each pathway, based on the user-specified gene signature definition.
+    """
+    positive_series_label = pd.Series(["pos"] * len(pathway_positive_series))
+    negative_series_label = pd.Series(["neg"] * len(pathway_negative_series))
+    side_information = positive_series_label.append(
+        negative_series_label)
+    side_information.index = index
+    side_information.name = "side"
+    return side_information
+
+
+def _significant_pathways_dataframe(pvalue_information,
+                                    side_information,
+                                    alpha):
+    """Create the significant pathways pandas.DataFrame.
+    Given the p-values corresponding to each pathway in a feature,
+    apply the FDR correction for multiple testing and remove those that
+    do not have a q-value of less than `alpha`.
+    """
+    significant_pathways = pd.concat(
+        [pvalue_information, side_information], axis=1)
+    below_alpha, qvalues, _, _ = multipletests(
+        significant_pathways["p-value"], alpha=alpha, method="fdr_bh")
+    below_alpha = pd.Series(
+        below_alpha, index=pvalue_information.index, name="pass")
+    qvalues = pd.Series(
+        qvalues, index=pvalue_information.index, name="q-value")
+    significant_pathways = pd.concat(
+        [significant_pathways, below_alpha, qvalues], axis=1)
+    significant_pathways = significant_pathways[significant_pathways["pass"]]
+    significant_pathways.drop("pass", axis=1, inplace=True)
+    significant_pathways.loc[:, "pathway"] = significant_pathways.index
+    return significant_pathways
+
+
+def single_side_pathway_enrichment(pathway_definitions,
+                                   gene_signature,
+                                   n_genes):
+    """Identify overrepresented pathways using the Fisher's exact test for
+    significance on a given pathway definition and gene signature.
+    (FDR correction for multiple testing is applied in
+    `_significant_pathways_dataframe`).
+
+    Parameters
+    -----------
+    pathway_definitions : dict(str -> set(str))
+      Pathway definitions, *post*-overlap-correction if this function
+      is called from `pathway_enrichment_with_overlap_correction`.
+      A pathway (key) is defined by a set of genes (value).
+    gene_signature : set(str)
+      The set of genes we consider to be enriched in a feature.
+    n_genes : int
+      The total number of genes for which we have assigned weights in the
+      features of an unsupervised model.
+
+    Returns
+    -----------
+    pandas.Series, for each pathway, the p-value from applying the Fisher's
+      exact test.
+    """
+    if not gene_signature:
+        return pd.Series(name="p-value")
+    pvalues_list = []
+    for pathway, definition in pathway_definitions.items():
+        if isinstance(definition, tuple):
+            definition = set.union(*definition)
+
+        both_definition_and_signature = len(definition & gene_signature)
+        in_definition_not_signature = (len(definition) -
+                                       both_definition_and_signature)
+        in_signature_not_definition = (len(gene_signature) -
+                                       both_definition_and_signature)
+        neither_definition_nor_signature = (n_genes -
+                                            both_definition_and_signature -
+                                            in_definition_not_signature -
+                                            in_signature_not_definition)
+        contingency_table = np.array(
+            [[both_definition_and_signature, in_signature_not_definition],
+             [in_definition_not_signature, neither_definition_nor_signature]])
+        try:
+            _, pvalue = stats.fisher_exact(
+                contingency_table, alternative="greater")
+            pvalues_list.append(pvalue)
+        # FPE can occur when `neither_definition_nor_signature` is very
+        # large and `both_definition_and_signature` is very small (near zero)
+        except FloatingPointError:
+            pvalues_list.append(1.0)
+    pvalues_series = pd.Series(
+        pvalues_list, index=pathway_definitions.keys(), name="p-value")
+    return pvalues_series
+
+
+def pathway_enrichment_no_overlap_correction(feature_weight_vector,
+                                             pathway_definitions,
+                                             gene_signature_definition,
+                                             alpha=0.05,
+                                             metadata=False):
+    """Identify pathways overrepresented in a constructed feature
+    according to a user-specified criterion (see `gene_signature_definitions`
+    in the parameters list below) for identifying the feature's gene
+    signature. Overlap-correction is not applied to the pathway definitions.
+
+    Parameters
+    -----------
+    feature_weight_vector : pandas.Series(float), shape = n
+      A vector containing gene weights
+    pathway_definitions : dict(str -> set(str))
+      A pathway (key) is defined by a set of genes (value).
+    gene_signature_definition : functools.partial callable,
+                                returns (set(), set())
+      Accepts the `feature_weight_vector` as input. Provide a function to
+      distinguish positive and/or negative gene signatures.
+      Both a positive & negative signature may be appropriate if the feature's
+      gene weight distribution spans positive and negative values. If this
+      is not the case, a user can just specify a single gene signature by
+      returning one or the other as an empty set.
+    alpha : float (default=0.05)
+      Significance level for pathway enrichment.
+    metadata : bool (default=False)
+      Return information about the gene signature(s)
+
+    Returns
+    -----------
+    tup([pandas.DataFrame|None], dict())
+    tup[0] : pandas.DataFrame: dataframe of significant pathways
+           | None if the gene signature does not contain any genes in the
+                  pathway definitions
+    tup[1] : if `metadata`:
+             {"positive signature": <set() positive gene signature>,
+              "negative signature": <set() negative gene signature>,
+              "pathway definitions": <dict(str -> set()) the pathway genes
+               that are in the gene signature(s)>}
+             else: {}
+    """
+    genes_in_pathway_definitions = set.union(*pathway_definitions.values())
+
+    positive_gene_signature, negative_gene_signature = \
+        gene_signature_definition(feature_weight_vector)
+    gene_signature = ((positive_gene_signature | negative_gene_signature) &
+                      genes_in_pathway_definitions)
+
+    if not gene_signature:
+        return (None, {})
+
+    additional_information = {}
+    n_genes = len(feature_weight_vector)
+
+    if metadata:
+        additional_information["positive_signature"] = positive_gene_signature
+        additional_information["negative_signature"] = negative_gene_signature
+
+        collect_signature_pathway_definitions = {}
+        for pathway, definition in pathway_definitions.items():
+            signature_definition = gene_signature & definition
+            if signature_definition:
+                collect_signature_pathway_definitions[pathway] = (
+                    signature_definition)
+        additional_information["pathway_definitions"] = (
+            collect_signature_pathway_definitions)
+
+    pathway_positive_series = single_side_pathway_enrichment(
+        pathway_definitions, positive_gene_signature, n_genes)
+    pathway_negative_series = single_side_pathway_enrichment(
+        pathway_definitions, negative_gene_signature, n_genes)
+    pvalue_information = pathway_positive_series.append(
+        pathway_negative_series)
+    side_information = _pathway_side_information(
+        pathway_positive_series, pathway_negative_series,
+        pvalue_information.index)
+    significant_pathways = _significant_pathways_dataframe(
+        pvalue_information, side_information, alpha)
+    return significant_pathways, additional_information

--- a/pathcore/network.py
+++ b/pathcore/network.py
@@ -1,0 +1,672 @@
+"""CoNetwork is the data structure that supports the pathway co-occurrence
+network produced by the PathCORE software.
+
+The classes Vertex and Edge are used in CoNetwork.
+"""
+import itertools
+import random
+
+import pandas as pd
+
+
+class Vertex:
+    """A pathway is represented as a Vertex object"""
+
+    def __init__(self, vertex_id):
+        self._id = vertex_id
+        self.edges = {}
+
+    def degree(self):
+        return len(self.edges)
+
+    def get_adjacent_vertex_ids(self):
+        return self.edges.keys()
+
+
+class Edge:
+    """A co-occurrence relationship between two pathways is
+    represented by an Edge object"""
+
+    def __init__(self, vertex0_id, vertex1_id, which_features=[]):
+        """
+        vertex0_id : int
+        vertex1_id : int
+        which_features : list (default=[])
+          The features in which this pathway-pathway relationship appears.
+        """
+        self.edge = (vertex0_id, vertex1_id)
+        # If `which_features` is initialized as the empty list, assume this is
+        # an unweighted network and set the weight to 1.
+        self.weight = 1 if not which_features else len(which_features)
+        self.which_features = which_features
+
+        # This flag is set to a bool value after a permutation test
+        # has been applied to the network. See `network_permutation_test.py`.
+        self.is_significant = None
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        else:
+            return sorted(self.edge) == sorted(other.edge)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def features_to_string(self):
+        return " ".join(map(str, self.which_features))
+
+    def connected_to(self, vertex_id):
+        """
+        Parameters
+        -----------
+        vertex_id : int
+          Get what `vertex_id` is connected to.
+
+        Returns
+        -----------
+        int|None, the vertex id connected to the
+          input `vertex_id` in this edge, as long as `vertex_id` is
+          one of the vertices connected by this edge.
+        """
+        if vertex_id not in self.edge:
+            return None
+        connected_to = (self.edge[1] if self.edge[0] == vertex_id
+                        else self.edge[0])
+        return connected_to
+
+
+class CoNetwork:
+
+    def __init__(self,
+                 model_n_features,
+                 significant_pathways=None,
+                 permutation_max_iters=30000):
+        """
+        model_n_features : int
+          the number of features the network is built from.
+        significant_pathways : str|pandas.DataFrame|None
+        - str: the path to a significant pathways file, which is then
+            loaded into a pandas.DataFrame. Must be tab-separated
+            and contain columns "feature," "pathway," and "side."
+        - pandas.DataFrame: the PathCORE analysis produces a significant
+            pathways pandas.DataFrame that a user can directly pass
+            to the CoNetwork constructor as well.
+        - None: Use the method `read_network_file` to load a PathCORE
+            network file as a CoNetwork object after a CoNetwork object
+            has been initialized with
+            CoNetwork(model_n_features, significant_pathways=None, ...).
+        permutation_max_iters : int (default=30000)
+          Sets an upper bound to the number of times we can randomly assign
+          a pathway to a feature during the side-preserving model permutation.
+        """
+        self.permutation_max_iters = permutation_max_iters
+
+        self.vertices = {}  # vertex id -> vertex object
+        self.edges = {}  # (vertex 0 id, vertex 1 id) -> edge object
+
+        self.n_features = model_n_features
+        self.features = set()
+
+        self.n_pathways = 0
+        self.pathways = {}  # pathway -> vertex id
+
+        if isinstance(significant_pathways, str):
+            self.feature_pathway_df = _load_significant_pathways_file(
+                significant_pathways)
+            self._construct_from_dataframe()
+        elif isinstance(significant_pathways, pd.DataFrame):
+            self.feature_pathway_df = significant_pathways
+            self._construct_from_dataframe()
+        elif isinstance(significant_pathways, dict):
+            self._construct_from_permutation(significant_pathways)
+
+    def __getitem__(self, search_id):
+        for pathway, vertex_id in self.pathways.items():
+            if search_id == vertex_id:
+                return pathway
+        return None
+
+    def read_network_file(self, path_to_network_file):
+        """
+        Parameters
+        -----------
+        path_to_network_file : str
+          Expects a network file with columns "pw0" and "pw1." A "features"
+          column that specifies the features where the (pw0, pw1) edge is
+          present will assign a weight to the edge, though it is not required
+          (edge will have weight 1 if no "features" column exists).
+              "features" format: space-separated feature numbers,
+              e.g. 0.0 1.0 2.0
+        """
+        network_df = pd.read_table(path_to_network_file)
+        network_edges = {}
+        for _, row in network_df.iterrows():
+            vertex0_id = self.add_pathway(row["pw0"])
+            vertex1_id = self.add_pathway(row["pw1"])
+            edge_id = self.edge_tuple(vertex0_id, vertex1_id)
+            if "features" in row:
+                network_edges[edge_id] = \
+                  [int(float(f)) for f in row["features"].split(" ")]
+            else:
+                network_edges[edge_id] = []
+        self._augment_network(network_edges)
+
+    def _construct_from_dataframe(self):
+        """Build the network using the significant pathways dataframe
+        by identifying pairwise direct (same-side) relationships.
+        """
+        direct_edges = {}
+        feature_side_grouping = self.feature_pathway_df.groupby(
+            ["feature", "side"])
+        for (feature, _), group in feature_side_grouping:
+            co_occurring_pathways = group["pathway"].tolist()
+            pairings = list(itertools.combinations(co_occurring_pathways, 2))
+            if not pairings:
+                continue
+            self.features.add(feature)
+            for pathway0, pathway1 in pairings:
+                vertex0_id = self.add_pathway(pathway0)
+                vertex1_id = self.add_pathway(pathway1)
+                new_edge = self.edge_tuple(vertex0_id, vertex1_id)
+                if new_edge not in direct_edges:
+                    direct_edges[new_edge] = []
+                direct_edges[new_edge].append(feature)
+        self._augment_network(direct_edges)
+
+    def _construct_from_permutation(self, significant_pathways):
+        """Build the network from a dictionary of (side -> tuple lists),
+        where the side is specified as "pos" and/or "neg" (from the feature
+        gene signature(s)) and mapped to a tuple list of [(pathway, feature)].
+        Used during the PathCORE permutation test by applying the method
+        `permute_pathways_across_features` to an existing CoNetwork.
+        """
+        for side, pathway_feature_tuples in significant_pathways.items():
+            feature_pathway_dict = self._collect_pathways_by_feature(
+                pathway_feature_tuples)
+            self._edges_from_permutation(feature_pathway_dict)
+
+    def permute_pathways_across_features(self):
+        """Return a permutation of the network. Requires that the
+        significant pathways file has been specified during CoNetwork
+        initialization (or set `self.feature_pathway_df` to the
+        pandas.DataFrame afterwards).
+        """
+        side_labels = self.feature_pathway_df.side.unique()
+        pathway_features = {}
+        for side in side_labels:
+            pathway_features[side] = []
+
+        feature_grouping = self.feature_pathway_df.groupby(
+            ["side", "feature"])
+
+        for (side, feature), group in feature_grouping:
+            pathways = group["pathway"].tolist()
+            for pathway in pathways:
+                pathway_features[side].append((pathway, feature))
+
+        permuted_network = {}
+        for side in side_labels:
+            pathway_side_permutation = _pathway_feature_permutation(
+                pathway_features[side], self.permutation_max_iters)
+            while pathway_side_permutation is None:
+                pathway_side_permutation = _pathway_feature_permutation(
+                    pathway_features[side], self.permutation_max_iters)
+            assert _permutation_correctness(
+                pathway_side_permutation, pathway_features[side]), \
+                ("Permutation on side {0} did not preserve the "
+                 "expected invariants").format(side)
+            permuted_network[side] = pathway_side_permutation
+        return CoNetwork(self.n_features,
+                         significant_pathways=permuted_network)
+
+    def weight_by_edge_odds_ratios(self,
+                                   edges_expected_weight,
+                                   flag_as_significant):
+        """Applied during the permutation test. Update the edges in the
+        network to be weighted by their odds ratios. The odds ratio measures
+        how unexpected the observed edge weight is based on the expected
+        weight.
+
+        Parameters
+        -----------
+        edges_expected_weight : list(tup(int, int), float)
+          A tuple list of (edge id, edge expected weight) generated from the
+          permutation test step.
+        flag_as_significant : [set|list](tup(int, int))
+          A set or list of edge ids that are considered significant against
+          the null model of random associations generated in the permutation
+          test
+        """
+        for edge_id, expected_weight in edges_expected_weight:
+            edge_obj = self.edges[edge_id]
+            edge_obj.weight /= expected_weight
+            if edge_id in flag_as_significant:
+                edge_obj.significant = True
+            else:
+                edge_obj.significant = False
+
+    def aggregate(self, merge):
+        """Combine this network with another network. The aggregation step
+        takes the union of the edges in the two networks, where we take the
+        sum of weights for edges common to both networks.
+
+        Parameters
+        -----------
+        merge : CoNetwork
+          the CoNetwork object being merged into the current network.
+        """
+        self.features = set()
+        self.n_features += merge.n_features
+
+        vertex_id_conversion = self.convert_pathway_mapping(merge.pathways)
+        for edge_id, edge in merge.edges.items():
+            edge_key = self.remapped_edge(
+                vertex_id_conversion, edge_id)
+            if edge_key in self.edges:
+                if self.edges[edge_key].which_features:
+                    self.edges[edge_key].which_features = []
+                self.edges[edge_key].weight += edge.weight
+            else:
+                vertex0_id, vertex1_id = edge_key
+                new_edge_obj = Edge(vertex0_id, vertex1_id, [])
+                new_edge_obj.weight = edge.weight
+                self.edges[edge_key] = new_edge_obj
+                self._add_edge_to_vertex(vertex0_id, new_edge_obj)
+                self._add_edge_to_vertex(vertex1_id, new_edge_obj)
+
+    def convert_pathway_mapping(self, other_pathway_mapping):
+        """Used to convert the pathway-to-vertex id mapping in one CoNetwork
+        to the one used in the current CoNetwork (`self`).
+        The following tasks are carried out in the remapping:
+        (1) If `self.pathways` contains the pathway to be merged, map the
+            vertex id in `other_pathway_mapping` to the vertex id
+            in `self.pathways`.
+        (2) If not, create a vertex in `self` and then add the key-value pair
+            to `self.pathways` accordingly.
+
+        Parameters
+        -----------
+        other_pathway_mapping : dict(str -> int)
+          the `pathways` field in the CoNetwork class. This is a
+          (pathway -> vertex id) map.
+
+        Returns
+        -----------
+        dict(int -> int), the (other vertex id -> `self` vertex id)
+          conversion map
+        """
+        vertex_id_conversion = {}
+        for pathway, vertex_id in other_pathway_mapping.items():
+            if pathway in self.pathways:
+                vertex_id_conversion[vertex_id] = self.pathways[pathway]
+            else:
+                self_vertex_id = self.add_pathway(pathway)
+                self.vertices[self_vertex_id] = Vertex(self_vertex_id)
+                vertex_id_conversion[vertex_id] = self_vertex_id
+        return vertex_id_conversion
+
+    def remapped_edge(self, vertex_id_conversion, other_edge_id):
+        """Given an edge (`vertex0_id`, `vertex1_id`) from a
+        different CoNetwork, return the corresponding edge id from this
+        CoNetwork (`self`).
+
+        Parameters
+        -----------
+        vertex_id_conversion : dict (int -> int)
+          the dict produced by `convert_pathway_mapping,` which maps
+          the other CoNetwork's vertex ids to this CoNetwork's vertex ids.
+        other_edge_id : tup(int, int)
+          the edge id for the edge in the other CoNetwork
+
+        Returns
+        -----------
+        tup(int, int), the corresponding edge id
+        """
+        vertex0_id, vertex1_id = other_edge_id
+        self_vertex0 = vertex_id_conversion[vertex0_id]
+        self_vertex1 = vertex_id_conversion[vertex1_id]
+        edge_id = self.edge_tuple(self_vertex0, self_vertex1)
+        return edge_id
+
+    def edge_tuple(self, vertex0_id, vertex1_id):
+        """To avoid duplicate edges where the vertex ids are reversed,
+        we maintain that the vertex ids are ordered so that the corresponding
+        pathway names are alphabetical.
+
+        Parameters
+        -----------
+        vertex0_id : int
+          one vertex in the edge
+        vertex1_id : int
+          the other vertex in the edge
+
+        Returns
+        -----------
+        tup(int, int)|None, the edge id or None if the vertices do not
+        exist in the network or they map to the same pathway (there should not
+        be any self-loops in the network)
+        """
+        pw0 = self.__getitem__(vertex0_id)
+        pw1 = self.__getitem__(vertex1_id)
+
+        if not pw0 or not pw1:
+            return None
+        if pw0 < pw1:
+            return (vertex0_id, vertex1_id)
+        elif pw0 > pw1:
+            return (vertex1_id, vertex0_id)
+        else:
+            return None
+
+    def add_pathway(self, pathway):
+        """Updates `self.pathways` and `self.n_pathways.`
+
+        Parameters
+        -----------
+        pathway : str
+          the pathway to add to the network.
+        """
+        if pathway not in self.pathways:
+            self.pathways[pathway] = self.n_pathways
+            self.n_pathways += 1
+        return self.pathways[pathway]
+
+    def get_pathway_from_vertex_id(self, vertex_id):
+        """Return the pathway string corresponding to a vertex id
+
+        Parameters
+        -----------
+        vertex_id : int
+
+        Returns
+        -----------
+        str|None, the pathway name if the vertex is in this network
+        """
+        return self.__getitem__(vertex_id)
+
+    def get_edge_pathways(self, edge_id):
+        """Get the pathways associated with an edge.
+
+        Parameters
+        -----------
+        edge_id : tup(int, int)
+
+        Returns
+        -----------
+        tup(str, str)|None, the edge as a pair of 2 pathways if the edge id
+          is in this network
+        """
+        vertex0_id, vertex1_id = edge_id
+        pw0 = self.get_pathway_from_vertex_id(vertex0_id)
+        pw1 = self.get_pathway_from_vertex_id(vertex1_id)
+        if not pw0 or not pw1:
+            return None
+        return (pw0, pw1)
+
+    def get_vertex_obj(self, vertex_id):
+        """Get the Vertex object that corresponds to a vertex id
+
+        Parameters
+        -----------
+        vertex_id : int
+
+        Returns
+        -----------
+        Vertex|None, the Vertex obj if the vertex id is in this network
+        """
+        if vertex_id in self.vertices:
+            return self.vertices[vertex_id]
+        return None
+
+    def get_vertex_obj_from_pathway(self, pathway):
+        """Get the vertex object that corresponds to a pathway name
+
+        Parameters
+        -----------
+        pathway : str
+
+        Returns
+        -----------
+        Vertex|None, the Vertex obj if the pathway is in this network
+        """
+        if pathway in self.pathways:
+            vertex_id = self.pathways[pathway]
+            return self.vertices[vertex_id]
+        else:
+            return None
+
+    def get_adjacent_pathways(self, pathway):
+        """Get the pathways adjacent to this pathway in the network
+
+        Parameters
+        -----------
+        pathway : str
+
+        Returns
+        -----------
+        list(str), a list of pathways adjacent to the input pathway
+        """
+        vertex_id = self.pathways[pathway]
+        adjacent = self.vertices[vertex_id].get_adjacent_vertex_ids()
+        adjacent_pathways = []
+        for adjacent_id in adjacent:
+            adjacent_pathways.append(self.get_pathway_from_vertex_id(
+                adjacent_id))
+        return adjacent_pathways
+
+    def to_dataframe(self, drop_weights_below=0, whitelist=None):
+        """ Conversion of the network to a pandas.DataFrame.
+
+        Parameters
+        -----------
+        drop_weights_below : int (default=0)
+          specify an edge weight threshold - remove all edges with weight
+          below this value
+        whitelist : [set|list](tup(int, int))|None (default=None)
+          option to pass in a set/list of edge ids (tup(int, int)) that should
+          be kept in the resulting dataframe
+
+        Returns
+        -----------
+        pandas.DataFrame
+          a pandas.DataFrame containing the network edge information.
+          columns = [pw0, pw1, weight]. an additional "features" column is
+          returned if this network is not an aggregate of multiple networks.
+        """
+        network_df_cols = ["pw0", "pw1", "weight"]
+        if self.features:
+            network_df_cols.append("features")
+        network_df = pd.DataFrame(columns=network_df_cols)
+        idx = 0
+        edge_pathways = set()
+        for (v0, v1), edge_obj in self.edges.items():
+            if (edge_obj.weight > drop_weights_below and
+                    (whitelist is None or (v0, v1) in whitelist)):
+                row = [self.__getitem__(v0),
+                       self.__getitem__(v1),
+                       edge_obj.weight]
+                edge_pathways.add(v0)
+                edge_pathways.add(v1)
+                if self.features:
+                    features = edge_obj.features_to_string()
+                    row.append(features)
+                network_df.loc[idx] = row
+                idx += 1  # faster to append by index.
+        network_df = network_df.sort_values(by=["weight"],
+                                            ascending=False)
+        print("The pathway co-occurrence network "
+              "contains {0} pathways.".format(
+                len(edge_pathways)))
+        return network_df
+
+    def _add_edge_to_vertex(self, vertex_id, edge):
+        """Adds the edge to the Vertex object's `edges` dictionary
+        """
+        connected_to = edge.connected_to(vertex_id)
+        if vertex_id not in self.vertices:
+            vertex_obj = Vertex(vertex_id)
+            self.vertices[vertex_id] = vertex_obj
+        self.vertices[vertex_id].edges[connected_to] = edge.weight
+
+    def _augment_network(self, edge_dict):
+        """Given a dictionary of edges (edge id -> feature list), add all of
+        these to the CoNetwork object
+        """
+        for (vertex0, vertex1), feature_list in edge_dict.items():
+            edge_obj = Edge(vertex0, vertex1, feature_list)
+            self.edges[(vertex0, vertex1)] = edge_obj
+            self._add_edge_to_vertex(vertex0, edge_obj)
+            self._add_edge_to_vertex(vertex1, edge_obj)
+
+    def _edges_from_permutation(self, feature_pathway_dict):
+        """Given a dictionary mapping each feature to the pathways
+        overrepresented in the feature, build a CoNetwork by
+        creating edges for every pairwise combination of pathways in a feature.
+        """
+        network_edges = {}
+        for feature, pathway_list in feature_pathway_dict.items():
+            for i in range(len(pathway_list)):
+                for j in range(i + 1, len(pathway_list)):
+                    vertex_i = pathway_list[i]
+                    vertex_j = pathway_list[j]
+                    new_edge = self.edge_tuple(vertex_i, vertex_j)
+                    if new_edge not in network_edges:
+                        network_edges[new_edge] = []
+                    network_edges[new_edge].append(feature)
+        self._augment_network(network_edges)
+
+    def _collect_pathways_by_feature(self, pathway_feature_tuples):
+        """Given a tuple list [(pathway, feature)], create a dictionary
+        mapping each feature to the pathways overrepresented in the feature.
+        """
+        pathways_in_feature = {}
+        for (pathway, feature) in pathway_feature_tuples:
+            vertex = self.add_pathway(pathway)
+            if feature not in pathways_in_feature:
+                pathways_in_feature[feature] = []
+            pathways_in_feature[feature].append(vertex)
+        return pathways_in_feature
+
+
+def _load_significant_pathways_file(path_to_file):
+    """Read in the significant pathways file as a
+    pandas.DataFrame.
+    """
+    feature_pathway_df = pd.read_table(
+        path_to_file, header=0,
+        usecols=["feature", "side", "pathway"])
+    feature_pathway_df = feature_pathway_df.sort_values(
+        by=["feature", "side"])
+    return feature_pathway_df
+
+################################################################
+# PATHWAY-FEATURE PERMUTATION HELPER FUNCTIONS.
+################################################################
+
+
+def _pathway_feature_permutation(pathway_feature_tuples,
+                                 permutation_max_iters):
+    """Permute the pathways across features for one side in the
+    network. Used in `permute_pathways_across_features`
+
+    Parameters
+    -----------
+    pathway_feature_tuples : list(tup(str, int))
+      a tuple list [(pathway, feature)] where the pathway, feature pairing
+      indicates that a pathway was overrepresented in that feature
+    permutation_max_iters : int
+      specify the maximum number of iterations, limit the number of attempts
+      we have to generate a permutation
+
+    Returns
+    -----------
+    list(tup(str, int)), the list of pathway, feature pairings after the
+      permutation
+    """
+
+    pathways, features = [list(elements_at_position)
+                          for elements_at_position in
+                          zip(*pathway_feature_tuples)]
+
+    original_pathways = pathways[:]
+
+    random.shuffle(pathways)
+    feature_block_locations = {}
+    i = 0
+    while i < len(pathways):
+        starting_index = i
+        current_feature = features[i]
+        pathway_set = set()
+        # input is grouped by feature, so we want to keep track of the start
+        # and end of a given "block" of the same feature--this corresponds
+        # to all the pathways overrepresented in that feature.
+        while i < len(pathways) and features[i] == current_feature:
+            # check the results of the permutation. if `pathway_set` does
+            # not contain the current pathway, we are maintaining the
+            # necessary invariants in our permutation thus far.
+            if pathways[i] not in pathway_set:
+                pathway_set.add(pathways[i])
+            else:
+                k = 0
+                random_pathway = None
+                while True:
+                    # select another random pathway from the list
+                    # and get the feature to which it belongs
+                    j = random.choice(range(0, len(pathways)))
+                    random_pathway = pathways[j]
+                    random_feature = features[j]
+                    if (random_pathway != pathways[i] and
+                            random_pathway not in pathway_set):
+                        # if this is a feature we have not already seen,
+                        # we are done.
+                        if random_feature not in feature_block_locations:
+                            break
+                        # otherwise, look at the indices that correspond
+                        # to that feature's block of pathways
+                        feature_block_start, feature_block_end = \
+                            feature_block_locations[random_feature]
+                        pathway_block = pathways[feature_block_start:
+                                                 feature_block_end]
+                        # make sure that the current pathway is not in
+                        # that block--ensures that we maintain the invariant
+                        # after the swap
+                        if pathways[i] not in pathway_block:
+                            break
+                    k += 1
+                    if k > permutation_max_iters:
+                        print("Permutation step: reached the maximum "
+                              "number of iterations {0}.".format(
+                                permutation_max_iters))
+                        return None
+                pathway_set.add(random_pathway)
+                pathways[j] = pathways[i]
+                pathways[i] = random_pathway
+            i += 1
+        ending_index = i
+        feature_block_locations[current_feature] = (
+            starting_index, ending_index)
+
+    if original_pathways == pathways:
+        return None
+    return list(zip(pathways, features))
+
+
+def _permutation_correctness(pathway_feature_tuples, original):
+    """Determine whether the generated permutation is a valid permutation.
+    Used in `permute_pathways_across_features`.
+    (Cannot be identical to the original significant pathways list,
+    and a feature should map to a distinct set of pathways.)
+    """
+    if pathway_feature_tuples:
+        if set(pathway_feature_tuples) == set(original):
+            return False
+        pathways_in_feature = {}
+        for (pathway, feature) in pathway_feature_tuples:
+            if feature not in pathways_in_feature:
+                pathways_in_feature[feature] = set()
+            if pathway in pathways_in_feature[feature]:
+                return False
+            else:
+                pathways_in_feature[feature].add(pathway)
+    return True

--- a/pathcore/network_permutation_test.py
+++ b/pathcore/network_permutation_test.py
@@ -62,7 +62,8 @@ def network_edges_permutation_test(observed_network,
       `network.py`)
     permuted_networks : list(CoNetwork)
       the list of N permuted networks generated from the original observed
-      network
+      CoNetwork by calling its `permute_pathways_across_features` function
+      N times and collecting the output in a list.
     alpha : float
       specify the threshold for significance testing
     n_networks : int (default=1)

--- a/pathcore/network_permutation_test.py
+++ b/pathcore/network_permutation_test.py
@@ -1,0 +1,185 @@
+"""Methods for permuting the pathways across constructed features of one
+or more unsupervised models.
+A permutation maintains the number of unique pathways that correspond to a
+feature. If applicable, it also preserves the side (positive or negative)
+in which pathway was overrepresented as well.
+"""
+import csv
+
+from statsmodels.sandbox.stats.multicomp import multipletests
+
+
+def aggregate_permuted_network(observed_networks):
+    """This method handles the case where multiple observed networks are
+    generated (e.g. from models produced by different random seed
+    initializations of an unsupervised feature construction algorithm).
+    We handle analysis of multiple networks by aggregating them; likewise,
+    we require that the permutation test generates N aggregate permuted
+    networks.
+
+    Parameters
+    -----------
+    observed_networks : list(CoNetwork)
+      the list of observed networks, generated from models produced by
+      different random seed initializations of the same unsupervised feature
+      construction algorithm
+
+    Returns
+    -----------
+    CoNetwork, the aggregate permuted network created by generating
+      a permutation for each individual observed network and then aggregating
+      them into a single network
+    """
+    aggregate_permuted_network = None
+    for pathcore_network in observed_networks:
+        permuted_network = pathcore_network.permute_pathways_across_features()
+        if not aggregate_permuted_network:
+            aggregate_permuted_network = permuted_network
+        else:
+            aggregate_permuted_network.aggregate(permuted_network)
+    return aggregate_permuted_network
+
+
+def network_edges_permutation_test(observed_network,
+                                   permuted_networks,
+                                   alpha,
+                                   n_networks=1,
+                                   output_edges_to_file=None,
+                                   output_network_to_file=None):
+    """Given the observed network and N permutations of that network,
+    determine the significance of each observed, weighted edge. Edges that
+    are not distinguishable from the null model of random associations will
+    be removed from the network file output. Additionally, weights of the
+    significant edges are updated to an odds ratio that quantifies the
+    "unexpectedness" of an observed pathway co-occurrence relationship
+    based on the generated null model.
+
+    Parameters
+    -----------
+    observed_network : CoNetwork
+      the original observed network (this can be an aggregate of
+      multiple networks, see CoNetwork's `aggregate` function in
+      `network.py`)
+    permuted_networks : list(CoNetwork)
+      the list of N permuted networks generated from the original observed
+      network
+    alpha : float
+      specify the threshold for significance testing
+    n_networks : int (default=1)
+      in the case where `observed_network` is an aggregate of multiple
+      co-occurrence networks, `n_networks` can be greater than 1.
+    output_edges_to_file : str|None (default=None)
+      specify the filepath to write the edges that had q-values
+      below `alpha`
+    output_network_to_file : str|None (default=None)
+      specify the filepath to write the final, filtered network
+
+    Returns
+    -----------
+    CoNetwork, the observed network after the permutation test (filtered
+    to only report significant edges, weighted by their odds ratios)
+    """
+    n_permutations = len(permuted_networks)
+    n_features = observed_network.n_features
+
+    edge_weight_distributions = _get_edge_weight_distributions(
+        observed_network, permuted_networks, n_networks * n_features)
+
+    pvalues = []
+    edge_expected_weight = []
+    for edge_id, edge_obj in observed_network.edges.items():
+        observed_weight = edge_obj.weight
+        weight_distribution = edge_weight_distributions[edge_id]
+        eq_or_above_observed = sum(weight_distribution[observed_weight:])
+        pvalue = eq_or_above_observed / float(n_permutations)
+        pvalues.append(pvalue)
+        edge_expected_weight.append((edge_id, _edge_expected_weight(
+            weight_distribution[1:])))
+
+    below_alpha, qvalues, _, _ = multipletests(
+        pvalues, alpha=alpha, method="fdr_bh")
+
+    significant_edge_indices = [index for index, passed in
+                                enumerate(below_alpha) if passed]
+    whitelist = set([edge_expected_weight[index][0] for index in
+                     significant_edge_indices])
+
+    observed_network.weight_by_edge_odds_ratios(
+        edge_expected_weight, whitelist)
+
+    n_significant_edges = len(significant_edge_indices)
+    print("{0} edges are significant under the null distribution, generated "
+          "from {1} permutations, for alpha = {2}.".format(n_significant_edges,
+                                                           n_permutations,
+                                                           alpha))
+    if output_edges_to_file:
+        _output_significant_edges_to_file(
+            output_edges_to_file, observed_network, edge_expected_weight,
+            pvalues, qvalues, significant_edge_indices)
+
+    if output_network_to_file:
+        observed_network_df = observed_network.to_dataframe(
+            whitelist=whitelist)
+        observed_network_df.to_csv(
+            output_network_to_file, sep="\t", index=False)
+
+    return observed_network
+
+
+def _get_edge_weight_distributions(observed_network,
+                                   permuted_networks,
+                                   max_possible_edge_weight):
+    """Helper function that returns the null distribution of each
+    observed, weighted edge.
+    """
+    edge_weight_distributions = {}
+    for edge in observed_network.edges.keys():
+        edge_weight_distributions[edge] = [0] * max_possible_edge_weight
+
+    for permuted_network in permuted_networks:
+        vertex_conversion = observed_network.convert_pathway_mapping(
+            permuted_network.pathways)
+        for permuted_edge_id, edge in permuted_network.edges.items():
+            edge_id = observed_network.remapped_edge(
+                vertex_conversion, permuted_edge_id)
+            if edge_id in edge_weight_distributions:
+                edge_weight_distributions[edge_id][edge.weight] += 1
+    return edge_weight_distributions
+
+
+def _edge_expected_weight(edge_weight_distribution):
+    """Helper function that computes the expected weight of an edge from
+    the given distribution
+    """
+    edge_exists_in_n_permutations = sum(edge_weight_distribution)
+    if not edge_exists_in_n_permutations:
+        return 1
+    sum_weight_counts = 0
+    for weight_index, n_permutations in enumerate(edge_weight_distribution):
+        sum_weight_counts += (weight_index + 1) * n_permutations
+
+    return sum_weight_counts / float(edge_exists_in_n_permutations)
+
+
+def _output_significant_edges_to_file(filepath,
+                                      observed_network,
+                                      edge_expected_weight,
+                                      pvalues,
+                                      qvalues,
+                                      significant_edge_indices):
+    """Helper function to report the results of the permutation test. Writes
+    the table of significant edges and their p-value & q-values to the
+    specified filepath.
+    """
+    with open(filepath, "w") as fp:
+        writer = csv.writer(fp, delimiter="\t")
+        writer.writerow(["pw0", "pw1",
+                         "pvalue", "qvalue", "odds_ratio"])
+        for index in significant_edge_indices:
+            edge_id, _ = edge_expected_weight[index]
+            pathway0, pathway1 = observed_network.get_edge_pathways(
+                edge_id)
+            odds_ratio = observed_network.edges[edge_id].weight
+            output = (pathway0, pathway1,
+                      pvalues[index], qvalues[index], odds_ratio)
+            writer.writerow(output)

--- a/pathcore/network_permutation_test.py
+++ b/pathcore/network_permutation_test.py
@@ -96,7 +96,7 @@ def network_edges_permutation_test(observed_network,
         pvalues.append(pvalue)
         edge_expected_weight.append((edge_id, _edge_expected_weight(
             weight_distribution[1:])))
-
+    # fdr_bh: false discovery rate, Benjamini & Hochberg (1995, 2000)
     below_alpha, qvalues, _, _ = multipletests(
         pvalues, alpha=alpha, method="fdr_bh")
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import os
+from setuptools import setup
+
+
+with open(os.path.join(os.path.dirname(__file__), "README.rst")) as readme:
+    long_description = readme.read()
+
+# Allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+setup(
+    name="PathCORE",
+    version="1.0.0",
+    packages=["pathcore"],
+    include_package_data=True,
+    license="LICENSE",
+    description="Python 3 implementation of PathCORE analysis methods",
+    long_description=long_description,
+    url="https://github.com/greenelab/PathCORE",
+    author="Greene Lab",
+    author_email="team@greenelab.com",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+    ],
+    install_requires=["crosstalk-correction", "numpy", "pandas",
+                      "scipy", "statsmodels"],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 import os
 from setuptools import setup
 
+setup_dir = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join(os.path.dirname(__file__), "README.rst")) as readme:
+with open(os.path.join(setup_dir, "README.rst")) as readme:
     long_description = readme.read()
 
 # Allow setup.py to be run from any path
-os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+os.chdir(os.path.normpath(os.path.join(setup_dir, os.pardir)))
 
 setup(
     name="PathCORE",
     version="1.0.0",
     packages=["pathcore"],
     include_package_data=True,
-    license="LICENSE",
+    license="BSD-3-Clause",
     description="Python 3 implementation of PathCORE analysis methods",
     long_description=long_description,
     url="https://github.com/greenelab/PathCORE",
@@ -27,6 +28,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
-    install_requires=["crosstalk-correction", "numpy", "pandas",
-                      "scipy", "statsmodels"],
+    install_requires=["crosstalk-correction",
+                      "numpy",
+                      "pandas",
+                      "scipy",
+                      "statsmodels"],
 )


### PR DESCRIPTION
This pull request looks very large--I want to start off by making it clear that the majority of the methods in this PR have been reviewed previously by @tj8901nm, but in contexts that were not PathCORE-specific. 

Please let me know if you think someone else would be more appropriate as a reviewer on this PR. Thanks!!

**NEEDS REVIEW:**
- Package-specific files: 
  - `README.rst` will have to be updated in a small follow-up PR once the PathCORE analysis repository (specific to the PathCORE paper case studies) to link to usage examples. Outside of the lack of examples, what else am I missing here?
  - `setup.py` same question as the previous point.
  - `__init__.py` same question
- `network_permutation_test.py`: I had some parts of this on bitbucket as well, but the components were more spread out (harder to directly link to something like I did below). This is the main thing that needs to be reviewed here!

**PREVIOUSLY REVIEWED:**
- `feature_overrepresentation_analysis.py`: original file [here](https://bitbucket.org/greenelab/eadage/src/d8a98586e0f448a5b7d497f5516cc4e241635361/ensemble_construction/pathway_coverage_no_crosstalk/pathway_coverage_no_crosstalk.py?at=default&fileviewer=file-view-default). This is exactly the same, minus documentation updates, to the file in the eADAGE repository. The major change is that the [crosstalk correction](https://github.com/kathyxchen/crosstalk-correction) procedure has been removed from the module and exists as its own Python package.

- `network.py`: original file [here](https://bitbucket.org/greenelab/pathway-network-construction/src/86d49074ae238f56d0ba3fe3d6f463c5bb068cda/network.py?at=default&fileviewer=file-view-default). Previously, we had considered creating data structures that handled 2 or even 3 types of edges, but this has been simplified to a single edge type. The `CoNetwork` class that exists in this module is a simplification of the original file. The implementation has not changed, but I've updated the documentation and function names for clarity. 